### PR TITLE
Fix typo in DAVE_SHADE.js where defining a uniform uint causes compilation error.

### DIFF
--- a/Source/editor/compileTime/shaders.js
+++ b/Source/editor/compileTime/shaders.js
@@ -153,6 +153,31 @@ function getTypedInput(type, name, index) {
 
       return input;
 
+    case "uint":
+      input = document.createElement("input");
+      input.style.width = "75%";
+
+      input.type = "Number";
+      input.value = 0;
+      input.className = "scratchStyledInput";
+      if (index !== undefined) {
+        input.value = penPlus.previousVariableStates[name + index] ? penPlus.previousVariableStates[name + index] : gl.shaders.editorShader.uniforms[name].elements[index].current;
+        if (penPlus.previousVariableStates[name + index]) gl.shaders.editorShader.uniforms[name].value = penPlus.previousVariableStates[name + index];
+        input.addEventListener("change", () => {
+          gl.shaders.editorShader.uniforms[name].elements[index].value = Math.floor(input.value);
+          penPlus.previousVariableStates[name + index] = gl.shaders.editorShader.uniforms[name].elements[index].current;
+        });
+      } else {
+        input.value = penPlus.previousVariableStates[name] ? penPlus.previousVariableStates[name] : gl.shaders.editorShader.uniforms[name].current;
+        if (penPlus.previousVariableStates[name]) gl.shaders.editorShader.uniforms[name].value = penPlus.previousVariableStates[name];
+        input.addEventListener("change", () => {
+          gl.shaders.editorShader.uniforms[name].value = Math.floor(input.value);
+          penPlus.previousVariableStates[name] = gl.shaders.editorShader.uniforms[name].current;
+        });
+      }
+
+      return input;
+
     case "vec2":
       input = document.createElement("div");
       input.style.width = "75%";

--- a/Source/render/DAVE_SHADE.js
+++ b/Source/render/DAVE_SHADE.js
@@ -104,7 +104,7 @@
               break;
 
             case "uint":
-              GL.uniform1u(GL.shaders[name].uniforms[uniformName].location, Math.floor(val));
+              GL.uniform1ui(GL.shaders[name].uniforms[uniformName].location, Math.floor(val));
               break;
 
             case "vec2":


### PR DESCRIPTION
Fix typo "GL.uniform1u" to "GL.uniform1ui" at line 107 in DAVE_SHADE.js
![image](https://github.com/user-attachments/assets/dbef4954-736a-4528-9386-e8d14abd459b)
